### PR TITLE
Fix zip function

### DIFF
--- a/libgin/archive.go
+++ b/libgin/archive.go
@@ -23,7 +23,7 @@ func MakeZip(dest io.Writer, source ...string) error {
 	zipwriter := zip.NewWriter(dest)
 	defer zipwriter.Close()
 
-	walker := func(filepath string, fi os.FileInfo, err error) error {
+	walker := func(path string, fi os.FileInfo, err error) error {
 
 		// return on any error
 		if err != nil {
@@ -38,7 +38,7 @@ func MakeZip(dest io.Writer, source ...string) error {
 
 		// update the name to correctly reflect the desired destination when unzipping
 		// header.Name = strings.TrimPrefix(strings.Replace(file, src, "", -1), string(filepath.Separator))
-		header.Name = filepath
+		header.Name = path
 
 		if fi.Mode().IsDir() {
 			return nil
@@ -52,7 +52,7 @@ func MakeZip(dest io.Writer, source ...string) error {
 
 		// Dereference symlinks
 		if fi.Mode()&os.ModeSymlink != 0 {
-			data, err := os.Readlink(filepath)
+			data, err := os.Readlink(path)
 			if err != nil {
 				return err
 			}
@@ -63,7 +63,7 @@ func MakeZip(dest io.Writer, source ...string) error {
 		}
 
 		// open files for zipping
-		f, err := os.Open(filepath)
+		f, err := os.Open(path)
 		defer f.Close()
 		if err != nil {
 			return err

--- a/libgin/archive.go
+++ b/libgin/archive.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 )
 
-// MakeZip creates a zip archive called dest from the files specified by source.
+// MakeZip creates a zip archive using the dest io.Writer from the files specified by source.
 // Any directories listed in source are archived recursively.
+// Empty directories are ignored.
 func MakeZip(dest io.Writer, source ...string) error {
 	// check sources
 	for _, src := range source {

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -6,12 +6,11 @@ import (
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
+	"log"
 	"net/http"
 	"regexp"
 	"strings"
 	"time"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 // NOTE: TEMPORARY COPIES FROM gin-doi
@@ -73,7 +72,7 @@ func (c *DOIRegInfo) GetCitation() string {
 func (c *DOIRegInfo) EscXML(txt string) string {
 	buf := new(bytes.Buffer)
 	if err := xml.EscapeText(buf, []byte(txt)); err != nil {
-		log.Errorf("Could not escape:%s, %+v", txt, err)
+		log.Printf("Could not escape: %s :: %s", txt, err.Error())
 		return ""
 	}
 	return buf.String()
@@ -125,7 +124,7 @@ func IsRegisteredDOI(doi string) bool {
 	url := fmt.Sprintf("https://doi.org/%s", doi)
 	resp, err := http.Get(url)
 	if err != nil {
-		log.Errorf("Could not query for doi: %s at %s", doi, url)
+		log.Printf("Could not query for DOI: %s at %s", doi, url)
 		return false
 	}
 	if resp.StatusCode != http.StatusNotFound {


### PR DESCRIPTION
- Directories were being added as empty files, messing up the archive
structure.
- It used to accept one source and multiple writers. Now it takes one
destination and multiple source files/directories to add.
- Tested against Info-ZIP and 7zip.