### PR TITLE
Variable name typo fix

### DIFF
--- a/libgin/dex.go
+++ b/libgin/dex.go
@@ -12,7 +12,7 @@ type SearchRequest struct {
 	Token  string
 	CsrfT  string
 	UserID int64
-	Querry string
+	Query  string
 	SType  int64
 }
 
@@ -20,7 +20,7 @@ const (
 	SEARCH_MATCH = iota
 	SEARCH_FUZZY
 	SEARCH_WILDCARD
-	SEARCH_QUERRY
+	SEARCH_QUERY
 	SEARCH_SUGGEST
 )
 

--- a/libgin/util.go
+++ b/libgin/util.go
@@ -20,6 +20,7 @@ func ReadConfDefault(key, defval string) string {
 func ReadConf(key string) string {
 	value, ok := os.LookupEnv(key)
 	if !ok {
+		// Exiting in a library function is weird and bad, but let's keep it FOR NOW
 		os.Exit(-1)
 	}
 	return value


### PR DESCRIPTION
Counterparts in gogs changed in G-Node/gogs#37.

Counterparts in gin-dex already changed in `dev` branch.