### PR TITLE
Remove dependence on G-Node/git-module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/G-Node/libgin
 go 1.12
 
 require (
-	github.com/G-Node/git-module v0.8.4-gnode4
 	github.com/gogs/git-module v0.8.3
+	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2 // indirect
+	github.com/smartystreets/goconvey v1.6.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,3 @@
-github.com/G-Node/gig v0.0.0-20171025133355-6d784b40b534/go.mod h1:H+82VbQUp9AzlbEiZl3bri3mlPlN2q6CxlIh0CyJWnc=
-github.com/G-Node/git-module v0.8.4-0.20191218161021-3fd4d7aaf932/go.mod h1:VYqGwMiaOacy+pch//bmTW0HnfVxZA6VnFSvzOOwpX0=
-github.com/G-Node/git-module v0.8.4-gnode4 h1:5V/0qMjrrKHwZI4LxM3346vjkw52189UprlUVLfnKgY=
-github.com/G-Node/git-module v0.8.4-gnode4/go.mod h1:TdKR+8dChXtB7Hw3xS4Bfn5QQenPnihuoWx/vnSnb1k=
-github.com/G-Node/libgin v0.0.0-20191216094436-47f8aadc0067/go.mod h1:2yLXQnNbwjH8mslxnzU8Kb+d7c2Zqo8DIgR6Pgp7lCg=
-github.com/G-Node/libgin v0.3.0/go.mod h1:VjulCBq7k/kgf4Eabk2f4w9SDNowWhLnK+yZvy5Nppk=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/gogs/git-module v0.8.3 h1:9f8oxSs9OACWrGBYMVnnQNzyTcVN+zzcBM7CXnbmezw=
 github.com/gogs/git-module v0.8.3/go.mod h1:aj4tcm7DxaszJWpZLZIRL6gfPXyguAHiE1PDfAAPrCw=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=

--- a/libgin/annex/add.go
+++ b/libgin/annex/add.go
@@ -3,7 +3,7 @@ package annex
 import (
 	"fmt"
 
-	git "github.com/G-Node/git-module"
+	"github.com/gogs/git-module"
 )
 
 const (
@@ -15,12 +15,12 @@ const (
 )
 
 func Init(dir string, args ...string) (string, error) {
-	cmd := git.NewACommand("init")
+	cmd := git.NewCommand("annex", "init")
 	return cmd.AddArguments(args...).RunInDir(dir)
 }
 
 func Uninit(dir string, args ...string) (string, error) {
-	cmd := git.NewACommand("uninit")
+	cmd := git.NewCommand("annex", "uninit")
 	return cmd.AddArguments(args...).RunInDir(dir)
 }
 
@@ -34,13 +34,13 @@ func MD5(dir string) (string, error) {
 	return cmd.RunInDir(dir)
 }
 
-func ASync(dir string, args ...string) (string, error) {
-	cmd := git.NewACommand("sync")
+func Sync(dir string, args ...string) (string, error) {
+	cmd := git.NewCommand("annex", "sync")
 	return cmd.AddArguments(args...).RunInDir(dir)
 }
 
 func Add(dir string, args ...string) (string, error) {
-	cmd := git.NewACommand("add")
+	cmd := git.NewCommand("annex", "add")
 	cmd.AddArguments(args...)
 	return cmd.RunInDir(dir)
 }


### PR DESCRIPTION
The last remaining G-Node/git-module dependency was for the "NewACommand" function, which simply runs a "git.NewCommand" with annex as the first argument.  Adding it directly to relevant commands instead is simpler and lets us remove the dependence on our fork (which we will soon delete).