### PR TITLE
Stricter ORCID parsing

### DIFF
--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -105,11 +105,12 @@ func (c *Author) GetValidID() *NamedIdentifier {
 	if c.ID == "" {
 		return nil
 	}
-	if strings.Contains(strings.ToLower(c.ID), "orcid") {
-		// assume the orcid id is a four block number thing eg. 0000-0002-5947-9939
-		var re = regexp.MustCompile(`(\d+-\d+-\d+-\d+)`)
-		nid := string(re.Find([]byte(c.ID)))
-		return &NamedIdentifier{URI: "https://orcid.org/", Scheme: "ORCID", ID: nid}
+	if strings.HasPrefix(strings.ToLower(c.ID), "orcid:") {
+		var re = regexp.MustCompile(`^([[:digit:]]{4}-){3}[[:digit:]]{4}$`)
+		orcid := strings.TrimPrefix(strings.ToLower(c.ID), "orcid:")
+		if re.Match([]byte(orcid)) {
+			return &NamedIdentifier{URI: fmt.Sprintf("https://orcid.org/%s", orcid), Scheme: "ORCID", ID: orcid}
+		}
 	}
 	return nil
 }

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -109,7 +109,6 @@ func (c *Author) GetValidID() *NamedIdentifier {
 		// four blocks of four numbers separated by dash; last character can be X
 		// https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier
 		var re = regexp.MustCompile(`([[:digit:]]{4}-){3}[[:digit:]]{3}[[:digit:]X]`)
-		// orcid := strings.TrimPrefix(strings.ToLower(c.ID), "orcid:")
 		if orcid := re.Find([]byte(c.ID)); orcid != nil {
 			return &NamedIdentifier{SchemeURI: "http://orcid.org/", Scheme: "ORCID", ID: string(orcid)}
 		}

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -106,7 +106,9 @@ func (c *Author) GetValidID() *NamedIdentifier {
 		return nil
 	}
 	if strings.HasPrefix(strings.ToLower(c.ID), "orcid:") {
-		var re = regexp.MustCompile(`^([[:digit:]]{4}-){3}[[:digit:]]{4}$`)
+		// four blocks of four numbers separated by dash; last character can be X
+		// https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier
+		var re = regexp.MustCompile(`^([[:digit:]]{4}-){3}[[:digit:]]{3}[[:digit:]X]$`)
 		orcid := strings.TrimPrefix(strings.ToLower(c.ID), "orcid:")
 		if re.Match([]byte(orcid)) {
 			return &NamedIdentifier{URI: fmt.Sprintf("https://orcid.org/%s", orcid), Scheme: "ORCID", ID: orcid}

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -105,13 +105,13 @@ func (c *Author) GetValidID() *NamedIdentifier {
 	if c.ID == "" {
 		return nil
 	}
-	if strings.HasPrefix(strings.ToLower(c.ID), "orcid:") {
+	if strings.HasPrefix(strings.ToLower(c.ID), "orcid") {
 		// four blocks of four numbers separated by dash; last character can be X
 		// https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier
-		var re = regexp.MustCompile(`^([[:digit:]]{4}-){3}[[:digit:]]{3}[[:digit:]X]$`)
-		orcid := strings.TrimPrefix(strings.ToLower(c.ID), "orcid:")
-		if re.Match([]byte(orcid)) {
-			return &NamedIdentifier{URI: fmt.Sprintf("https://orcid.org/%s", orcid), Scheme: "ORCID", ID: orcid}
+		var re = regexp.MustCompile(`([[:digit:]]{4}-){3}[[:digit:]]{3}[[:digit:]X]`)
+		// orcid := strings.TrimPrefix(strings.ToLower(c.ID), "orcid:")
+		if orcid := re.Find([]byte(c.ID)); orcid != nil {
+			return &NamedIdentifier{URI: fmt.Sprintf("https://orcid.org/%s", string(orcid)), Scheme: "ORCID", ID: string(orcid)}
 		}
 	}
 	return nil

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -111,7 +111,7 @@ func (c *Author) GetValidID() *NamedIdentifier {
 		var re = regexp.MustCompile(`([[:digit:]]{4}-){3}[[:digit:]]{3}[[:digit:]X]`)
 		// orcid := strings.TrimPrefix(strings.ToLower(c.ID), "orcid:")
 		if orcid := re.Find([]byte(c.ID)); orcid != nil {
-			return &NamedIdentifier{URI: fmt.Sprintf("https://orcid.org/%s", string(orcid)), Scheme: "ORCID", ID: string(orcid)}
+			return &NamedIdentifier{SchemeURI: "http://orcid.org/", Scheme: "ORCID", ID: string(orcid)}
 		}
 	}
 	return nil
@@ -122,9 +122,9 @@ func (a *Author) RenderAuthor() string {
 }
 
 type NamedIdentifier struct {
-	URI    string
-	Scheme string
-	ID     string
+	SchemeURI string
+	Scheme    string
+	ID        string
 }
 
 type Reference struct {


### PR DESCRIPTION
Stricter (and corrected) regex for finding ORCID in datacite.yml.

Additionally, the URI in the NamedIdentifier struct has been renamed to SchemeURI to make its purpose clearer.