### PR TITLE
DataCite XML struct

### DIFF
--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -44,9 +44,9 @@ type RelatedIdentifier struct {
 }
 
 type FundingReference struct {
-	Funder         string `xml:"funderName"`
-	Identifier     string `xml:"funderIdentifier"`
-	IdentifierType string `xml:"funderIdentifierType,attr"`
+	Funder      string `xml:"funderName"`
+	AwardNumber string `xml:"awardNumber"`
+	// TODO: Add identifier for known funders
 }
 
 type Contributor struct {
@@ -121,18 +121,17 @@ func (dc *DataCite) SetResourceType(resourceType string) {
 }
 
 // AddFunding is a convenience function for appending a FundingReference in the
-// format of the YAML data (FUNDER, ID) without needing to specify the
-// "Crossref Funder ID" funderIdentifierType.
+// format of the YAML data (<FUNDER>, <AWARDNUMBER>).
 func (dc *DataCite) AddFunding(fundstr string) {
 	funParts := strings.SplitN(fundstr, ",", 2)
-	var funder, id string
+	var funder, awardNumber string
 	if len(funParts) == 2 {
 		funder = strings.TrimSpace(funParts[0])
-		id = strings.TrimSpace(funParts[1])
+		awardNumber = strings.TrimSpace(funParts[1])
 	} else {
-		// No comma, add to ID as is
-		id = fundstr
+		// No comma, add to award number as is
+		awardNumber = fundstr
 	}
-	fundref := FundingReference{Funder: funder, Identifier: id, IdentifierType: "Crossref Funder ID"}
+	fundref := FundingReference{Funder: funder, AwardNumber: awardNumber}
 	dc.FundingReferences = append(dc.FundingReferences, fundref)
 }

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -72,7 +72,7 @@ type DataCite struct {
 	// Creators: Authors
 	Creators     []Creator     `xml:"creators>creator"`
 	Titles       []string      `xml:"titles>title"`
-	Descriptions []Description `xml:"descriptions"`
+	Descriptions []Description `xml:"descriptions>description"`
 	// RightsList: Licenses
 	RightsList Rights `xml:"rightsList>rights"`
 	// Subjects: Keywords

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -75,7 +75,7 @@ type DataCite struct {
 	Titles       []string      `xml:"titles>title"`
 	Descriptions []Description `xml:"descriptions>description"`
 	// RightsList: Licenses
-	RightsList Rights `xml:"rightsList>rights"`
+	RightsList []Rights `xml:"rightsList>rights"`
 	// Subjects: Keywords
 	Subjects []string `xml:"subjects>subject,omitempty"`
 	// RelatedIdentifiers: References

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -115,6 +115,12 @@ func NewDataCite() DataCite {
 	}
 }
 
+// AddAbstract is a convenience function for adding a Description with type
+// "Abstract".
+func (dc *DataCite) AddAbstract(abstract string) {
+	dc.Descriptions = append(dc.Descriptions, Description{Content: abstract, Type: "Abstract"})
+}
+
 // SetResourceType is a convenience function for setting the ResourceType data
 // and its resourceTypeGeneral to the same value.
 func (dc *DataCite) SetResourceType(resourceType string) {

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -1,0 +1,138 @@
+package libgin
+
+import (
+	"encoding/xml"
+	"strings"
+	"time"
+)
+
+const (
+	Schema         = "http://www.w3.org/2001/XMLSchema-instance"
+	Namespace      = "http://datacite.org/schema/kernel-4"
+	SchemaLocation = "http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd"
+	Publisher      = "G-Node"
+	Language       = "eng"
+	Version        = "1.0"
+)
+
+type NameIdentifier struct {
+	ID        string `xml:",chardata"`
+	SchemeURI string `xml:"schemeURI,attr"`
+	Scheme    string `xml:"nameIdentifierScheme,attr"`
+}
+
+type Creator struct {
+	Name        string          `xml:"creatorName"`
+	Identifier  *NameIdentifier `xml:"nameIdentifier,omitempty"`
+	Affiliation string          `xml:"affiliation,omitempty"`
+}
+
+type Description struct {
+	Content string `xml:",chardata"`
+	Type    string `xml:"descriptionType,attr"`
+}
+
+type Rights struct {
+	Name string `xml:",chardata"`
+	URL  string `xml:"rightsURI,attr"`
+}
+
+type RelatedIdentifier struct {
+	Identifier   string `xml:",chardata"`
+	Type         string `xml:"relatedIdentifierType,attr"`
+	RelationType string `xml:"relationType,attr"`
+}
+
+type FundingReference struct {
+	Funder         string `xml:"funderName"`
+	Identifier     string `xml:"funderIdentifier"`
+	IdentifierType string `xml:"funderIdentifierType,attr"`
+}
+
+type Contributor struct {
+	Name string `xml:"contributorName"`
+	Type string `xml:"contributorType,attr"`
+}
+
+type Date struct {
+	Value string `xml:",chardata"`
+	// Always set to "Issued"
+	Type string `xml:"dateType,attr"`
+}
+
+type ResourceType struct {
+	Value   string `xml:",chardata"`
+	General string `xml:"resourceTypeGeneral,attr"`
+}
+type DataCite struct {
+	XMLName        xml.Name `xml:"resource"`
+	Schema         string   `xml:"xmlns:xsi,attr"`
+	Namespace      string   `xml:"xmlns,attr"`
+	SchemaLocation string   `xml:"xsi:schemaLocation,attr"`
+	// Creators: Authors
+	Creators     []Creator     `xml:"creators>creator"`
+	Titles       []string      `xml:"titles>title"`
+	Descriptions []Description `xml:"descriptions"`
+	// RightsList: Licenses
+	RightsList Rights `xml:"rightsList>rights"`
+	// Subjects: Keywords
+	Subjects []string `xml:"subjects>subject,omitempty"`
+	// RelatedIdentifiers: References
+	RelatedIdentifiers []RelatedIdentifier `xml:"relatedIdentifiers,omitempty>relatedIdentifier"`
+	FundingReferences  []FundingReference  `xml:"fundingReferences,omitempty>fundingReference"`
+	// Contributors: Always German Neuroinformatics Node with type "HostingInstitution"
+	Contributors []Contributor `xml:"contributors>contributor"`
+	// Publisher: Always G-Node
+	Publisher string `xml:"publisher"`
+	// Publication Year
+	Year int `xml:"publicationYear"`
+	// Publication Date marked with type "Issued"
+	Dates []Date `xml:"dates>date"`
+	// Language: eng
+	Language     string       `xml:"language"`
+	ResourceType ResourceType `xml:"resourceType"`
+	// Version: 1.0
+	Version string `xml:"version"`
+}
+
+// Returns a DataCite struct populated with our defaults.
+// The following values are set and generally shouldn't be changed:
+// Schema, Namespace, SchemaLocation, Contributors, Publisher, Language, Version.
+// Dates and Year are also pre-filled with the current date but should be
+// changed when working with an existing publication.
+func NewDataCite() DataCite {
+	return DataCite{
+		Schema:         Schema,
+		Namespace:      Namespace,
+		SchemaLocation: SchemaLocation,
+		Contributors:   []Contributor{Contributor{"German Neuroinformatics Node", "HostingInstitution"}},
+		Publisher:      Publisher,
+		Year:           time.Now().Year(),
+		Dates:          []Date{Date{time.Now().Format("2006-01-02"), "Issued"}},
+		Language:       Language,
+		Version:        Version,
+	}
+}
+
+// SetResourceType is a convenience function for setting the ResourceType data
+// and its resourceTypeGeneral to the same value.
+func (dc *DataCite) SetResourceType(resourceType string) {
+	dc.ResourceType = ResourceType{resourceType, resourceType}
+}
+
+// AddFunding is a convenience function for appending a FundingReference in the
+// format of the YAML data (FUNDER, ID) without needing to specify the
+// "Crossref Funder ID" funderIdentifierType.
+func (dc *DataCite) AddFunding(fundstr string) {
+	funParts := strings.SplitN(fundstr, ",", 2)
+	var funder, id string
+	if len(funParts) == 2 {
+		funder = strings.TrimSpace(funParts[0])
+		id = strings.TrimSpace(funParts[1])
+	} else {
+		// No comma, add to ID as is
+		id = fundstr
+	}
+	fundref := FundingReference{Funder: funder, Identifier: id, IdentifierType: "Crossref Funder ID"}
+	dc.FundingReferences = append(dc.FundingReferences, fundref)
+}

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -2,6 +2,7 @@ package libgin
 
 import (
 	"encoding/xml"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -134,4 +135,39 @@ func (dc *DataCite) AddFunding(fundstr string) {
 	}
 	fundref := FundingReference{Funder: funder, AwardNumber: awardNumber}
 	dc.FundingReferences = append(dc.FundingReferences, fundref)
+}
+
+// AddReference is a convenience function for appending a RelatedIdentifier
+// that describes a referenced work. The RelatedIdentifier includes the
+// identifier, relation type, and identifier type. A full citation string is
+// also added to the Descriptions list.
+func (dc *DataCite) AddReference(ref *Reference) {
+	// Add info as RelatedIdentifier
+	refIDParts := strings.SplitN(ref.ID, ":", 2)
+	var relIDType, relID string
+	if len(refIDParts) == 2 {
+		relIDType = strings.TrimSpace(refIDParts[0])
+		relID = strings.TrimSpace(refIDParts[1])
+	} else {
+		// No colon, add to ID as is
+		relID = ref.ID
+	}
+
+	relatedIdentifier := RelatedIdentifier{Identifier: relID, Type: relIDType, RelationType: ref.Reftype}
+	dc.RelatedIdentifiers = append(dc.RelatedIdentifiers, relatedIdentifier)
+
+	// Add citation string as Description
+	var namecitation string
+	if ref.Name != "" && ref.Citation != "" {
+		namecitation = ref.Name + " " + ref.Citation
+	} else {
+		namecitation = ref.Name + ref.Citation
+	}
+
+	if !strings.HasSuffix(namecitation, ".") {
+		namecitation += "."
+	}
+	refDesc := Description{Content: fmt.Sprintf("%s: %s (%s)", ref.Reftype, namecitation, ref.ID), Type: "Other"}
+
+	dc.Descriptions = append(dc.Descriptions, refDesc)
 }

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -79,7 +79,7 @@ type DataCite struct {
 	Subjects []string `xml:"subjects>subject,omitempty"`
 	// RelatedIdentifiers: References
 	RelatedIdentifiers []RelatedIdentifier `xml:"relatedIdentifiers,omitempty>relatedIdentifier"`
-	FundingReferences  []FundingReference  `xml:"fundingReferences,omitempty>fundingReference"`
+	FundingReferences  []FundingReference  `xml:"fundingReferences>fundingReference,omitempty"`
 	// Contributors: Always German Neuroinformatics Node with type "HostingInstitution"
 	Contributors []Contributor `xml:"contributors>contributor"`
 	// Publisher: Always G-Node

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -80,7 +80,7 @@ type DataCite struct {
 	// Subjects: Keywords
 	Subjects []string `xml:"subjects>subject,omitempty"`
 	// RelatedIdentifiers: References
-	RelatedIdentifiers []RelatedIdentifier `xml:"relatedIdentifiers,omitempty>relatedIdentifier"`
+	RelatedIdentifiers []RelatedIdentifier `xml:"relatedIdentifiers>relatedIdentifier,omitempty"`
 	FundingReferences  []FundingReference  `xml:"fundingReferences>fundingReference,omitempty"`
 	// Contributors: Always German Neuroinformatics Node with type "HostingInstitution"
 	Contributors []Contributor `xml:"contributors>contributor"`

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -1,0 +1,43 @@
+package libgin
+
+import (
+	"encoding/xml"
+	"fmt"
+	"testing"
+)
+
+func Test_DataCiteMarshal(t *testing.T) {
+	example := NewDataCite()
+	example.Creators = []Creator{
+		Creator{"Achilleas", &NameIdentifier{"0010", "http://orcid.org", "ORCID"}, "University of Bob"},
+		Creator{"Bob", &NameIdentifier{"1111", "http://orcid.org", "ORCID"}, "University of University"},
+		Creator{"Orphan", nil, ""},
+	}
+
+	example.Titles = []string{"This is a sample"}
+	example.Descriptions = []Description{
+		Description{"This is the abstract", "Abstract"},
+		Description{"This is something else\nSomething else entirely", "Other"}, // TODO: Line breaks
+	}
+	example.RightsList = Rights{"CC-BY", "http://creativecommons.org/licenses/by/4.0/"}
+	example.Subjects = []string{"One", "Two", "Three"}
+	example.FundingReferences = []FundingReference{
+		FundingReference{"DFG", "DFG.12345", "Crossref Funder ID"},
+		FundingReference{"EU", "EU.12345", "Crossref Funder ID"},
+	}
+	// example.AddFunding("DFG, DFG.12345")
+	// example.AddFunding("EU, EU.12345")
+	example.RelatedIdentifiers = []RelatedIdentifier{
+		RelatedIdentifier{"10.1111/fake.doi", "DOI", "IsDescribedBy"},
+		RelatedIdentifier{"10.2222/fake.doi", "DOI", "IsSupplementTo"},
+		RelatedIdentifier{"10.3333/fake.doi", "DOI", "IsReferencedBy"},
+	}
+	example.SetResourceType("Dataset")
+
+	dataciteXML, err := xml.MarshalIndent(example, "", "\t")
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v\n", err)
+	}
+
+	fmt.Println(xml.Header + string(dataciteXML))
+}

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -15,9 +15,7 @@ func Test_DataCiteMarshal(t *testing.T) {
 	}
 
 	example.Titles = []string{"This is a sample"}
-	example.Descriptions = []Description{
-		Description{"This is the abstract", "Abstract"},
-	}
+	example.AddAbstract("This is the abstract")
 	example.RightsList = Rights{"CC-BY", "http://creativecommons.org/licenses/by/4.0/"}
 	example.Subjects = []string{"One", "Two", "Three"}
 	example.AddFunding("DFG, DFG.12345")

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -21,12 +21,8 @@ func Test_DataCiteMarshal(t *testing.T) {
 	}
 	example.RightsList = Rights{"CC-BY", "http://creativecommons.org/licenses/by/4.0/"}
 	example.Subjects = []string{"One", "Two", "Three"}
-	example.FundingReferences = []FundingReference{
-		FundingReference{"DFG", "DFG.12345", "Crossref Funder ID"},
-		FundingReference{"EU", "EU.12345", "Crossref Funder ID"},
-	}
-	// example.AddFunding("DFG, DFG.12345")
-	// example.AddFunding("EU, EU.12345")
+	example.AddFunding("DFG, DFG.12345")
+	example.AddFunding("EU, EU.12345")
 	example.RelatedIdentifiers = []RelatedIdentifier{
 		RelatedIdentifier{"10.1111/fake.doi", "DOI", "IsDescribedBy"},
 		RelatedIdentifier{"10.2222/fake.doi", "DOI", "IsSupplementTo"},

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -26,6 +26,61 @@ func Test_DataCiteMarshal(t *testing.T) {
 	example.AddReference(&Reference{ID: "arxiv:10.2222/example.doi", Reftype: "IsSupplementTo", Name: "Some other work"})
 	example.AddReference(&Reference{ID: "doi:10.3333/example.doi", Reftype: "IsReferencedBy", Name: "A work that references this dataset."})
 
+	_, err := xml.MarshalIndent(example, "", "\t")
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v\n", err)
+	}
+
+	// fmt.Println(xml.Header + string(dataciteXML))
+}
+
+func Test_DataCiteFromRegInfo(t *testing.T) {
+	authors := []Author{
+		Author{
+			FirstName:   "GivenName1",
+			LastName:    "FamilyName1",
+			Affiliation: "Affiliation1",
+			ID:          "ORCID:0000-0001-2345-6789",
+		},
+		Author{
+			FirstName:   "GivenName2",
+			LastName:    "FamilyName2",
+			Affiliation: "Affiliation2",
+			ID:          "ResearcherID:X-1234-5678",
+		},
+		Author{
+			FirstName: "GivenName3",
+			LastName:  "FamilyName3",
+		},
+	}
+	references := []Reference{
+		Reference{
+			ID:      "doi:10.xxx/zzzz",
+			Reftype: "IsSupplementTo",
+			Name:    "PublicationName1",
+		},
+		Reference{
+			ID:      "arxiv:mmmm.nnnn",
+			Reftype: "IsDescribedBy",
+			Name:    "PublicationName2",
+		},
+		Reference{
+			ID:      "pmid:nnnnnnnn",
+			Reftype: "IsReferencedBy",
+			Name:    "PublicationName3",
+		},
+	}
+	regInfo := &DOIRegInfo{
+		Authors:      authors,
+		Title:        "This is a sample",
+		Description:  "This is the abstract",
+		Keywords:     []string{"Neuroscience", "Electrophysiology"},
+		License:      &License{"Creative Commons CC0 1.0 Public Domain Dedication", "https://creativecommons.org/publicdomain/zero/1.0/"},
+		Funding:      []string{"DFG, DFG.12345", "EU, EU.12345"},
+		References:   references,
+		ResourceType: "Dataset",
+	}
+	example := NewDataCiteFromRegInfo(regInfo)
 	dataciteXML, err := xml.MarshalIndent(example, "", "\t")
 	if err != nil {
 		t.Fatalf("Failed to marshal: %v\n", err)

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -17,20 +17,16 @@ func Test_DataCiteMarshal(t *testing.T) {
 	example.Titles = []string{"This is a sample"}
 	example.Descriptions = []Description{
 		Description{"This is the abstract", "Abstract"},
-		Description{"IsDescribedBy: Manuscript title for reference. doi:10.1111/example.doi", "Other"}, // TODO: Line breaks
-		Description{"IsSupplementTo: Some other work. arxiv:10.2222/example.doi", "Other"},
-		Description{"IsReferencedBy: A work that references this dataset. doi:10.3333/example.doi", "Other"},
 	}
 	example.RightsList = Rights{"CC-BY", "http://creativecommons.org/licenses/by/4.0/"}
 	example.Subjects = []string{"One", "Two", "Three"}
 	example.AddFunding("DFG, DFG.12345")
 	example.AddFunding("EU, EU.12345")
-	example.RelatedIdentifiers = []RelatedIdentifier{
-		RelatedIdentifier{"10.1111/example.doi", "DOI", "IsDescribedBy"},
-		RelatedIdentifier{"10.2222/example.doi", "arxiv", "IsSupplementTo"},
-		RelatedIdentifier{"10.3333/example.doi", "DOI", "IsReferencedBy"},
-	}
 	example.SetResourceType("Dataset")
+
+	example.AddReference(&Reference{ID: "doi:10.1111/example.doi", Reftype: "IsDescribedBy", Name: "Manuscript title for reference."})
+	example.AddReference(&Reference{ID: "arxiv:10.2222/example.doi", Reftype: "IsSupplementTo", Name: "Some other work"})
+	example.AddReference(&Reference{ID: "doi:10.3333/example.doi", Reftype: "IsReferencedBy", Name: "A work that references this dataset."})
 
 	dataciteXML, err := xml.MarshalIndent(example, "", "\t")
 	if err != nil {

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -16,7 +16,7 @@ func Test_DataCiteMarshal(t *testing.T) {
 
 	example.Titles = []string{"This is a sample"}
 	example.AddAbstract("This is the abstract")
-	example.RightsList = Rights{"CC-BY", "http://creativecommons.org/licenses/by/4.0/"}
+	example.RightsList = []Rights{Rights{"CC-BY", "http://creativecommons.org/licenses/by/4.0/"}}
 	example.Subjects = []string{"One", "Two", "Three"}
 	example.AddFunding("DFG, DFG.12345")
 	example.AddFunding("EU, EU.12345")

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -17,16 +17,18 @@ func Test_DataCiteMarshal(t *testing.T) {
 	example.Titles = []string{"This is a sample"}
 	example.Descriptions = []Description{
 		Description{"This is the abstract", "Abstract"},
-		Description{"This is something else\nSomething else entirely", "Other"}, // TODO: Line breaks
+		Description{"IsDescribedBy: Manuscript title for reference. doi:10.1111/example.doi", "Other"}, // TODO: Line breaks
+		Description{"IsSupplementTo: Some other work. arxiv:10.2222/example.doi", "Other"},
+		Description{"IsReferencedBy: A work that references this dataset. doi:10.3333/example.doi", "Other"},
 	}
 	example.RightsList = Rights{"CC-BY", "http://creativecommons.org/licenses/by/4.0/"}
 	example.Subjects = []string{"One", "Two", "Three"}
 	example.AddFunding("DFG, DFG.12345")
 	example.AddFunding("EU, EU.12345")
 	example.RelatedIdentifiers = []RelatedIdentifier{
-		RelatedIdentifier{"10.1111/fake.doi", "DOI", "IsDescribedBy"},
-		RelatedIdentifier{"10.2222/fake.doi", "DOI", "IsSupplementTo"},
-		RelatedIdentifier{"10.3333/fake.doi", "DOI", "IsReferencedBy"},
+		RelatedIdentifier{"10.1111/example.doi", "DOI", "IsDescribedBy"},
+		RelatedIdentifier{"10.2222/example.doi", "arxiv", "IsSupplementTo"},
+		RelatedIdentifier{"10.3333/example.doi", "DOI", "IsReferencedBy"},
 	}
 	example.SetResourceType("Dataset")
 


### PR DESCRIPTION
This PR introduces a data struct for producing a datacite.xml by marshaling.  It does not cover the full range of DataCite metadata, but only the ones we use for dataset registration on GIN.

Some tests are included.  The tests simply marshal and print some preset data.  This will be extended to check the output against preset output.

The DataCite type contains methods for conveniently adding data, which can be used externally to populate it, but is also used for conversion from the old DOIRegInfo type to DataCite.

The new AuthorID parsing function includes a copy of the parsing code from the doi.go file.  This will be removed in a later PR.  The new function is tested with both invalid data and valid data from both kinds of supported IDs.