### PR TITLE
Data structure reorganisation

### DIFF
--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -200,7 +200,7 @@ func (dc *DataCite) AddReference(ref *Reference) {
 	refIDParts := strings.SplitN(ref.ID, ":", 2)
 	var relIDType, relID string
 	if len(refIDParts) == 2 {
-		relIDType := strings.TrimSpace(refIDParts[0])
+		relIDType = strings.TrimSpace(refIDParts[0])
 		if ridt, ok := relIDTypeMap[strings.ToLower(relIDType)]; ok {
 			relIDType = ridt
 		}

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -156,7 +156,7 @@ func parseAuthorID(authorID string) *NameIdentifier {
 func (dc *DataCite) AddAuthor(author *Author) {
 	ident := parseAuthorID(author.ID)
 	creator := Creator{
-		Name:        fmt.Sprintf("%s %s", author.FirstName, author.LastName),
+		Name:        fmt.Sprintf("%s, %s", author.LastName, author.FirstName),
 		Identifier:  ident,
 		Affiliation: author.Affiliation,
 	}

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -66,6 +66,7 @@ type ResourceType struct {
 	Value   string `xml:",chardata"`
 	General string `xml:"resourceTypeGeneral,attr"`
 }
+
 type DataCite struct {
 	XMLName        xml.Name `xml:"resource"`
 	Schema         string   `xml:"xmlns:xsi,attr"`
@@ -195,7 +196,7 @@ func (dc *DataCite) AddReference(ref *Reference) {
 		relID = ref.ID
 	}
 
-	relatedIdentifier := RelatedIdentifier{Identifier: relID, Type: relIDType, RelationType: ref.Reftype}
+	relatedIdentifier := RelatedIdentifier{Identifier: relID, Type: relIDType, RelationType: ref.RefType}
 	dc.RelatedIdentifiers = append(dc.RelatedIdentifiers, relatedIdentifier)
 
 	// Add citation string as Description
@@ -209,26 +210,26 @@ func (dc *DataCite) AddReference(ref *Reference) {
 	if !strings.HasSuffix(namecitation, ".") {
 		namecitation += "."
 	}
-	refDesc := Description{Content: fmt.Sprintf("%s: %s (%s)", ref.Reftype, namecitation, ref.ID), Type: "Other"}
+	refDesc := Description{Content: fmt.Sprintf("%s: %s (%s)", ref.RefType, namecitation, ref.ID), Type: "Other"}
 
 	dc.Descriptions = append(dc.Descriptions, refDesc)
 }
 
-func NewDataCiteFromRegInfo(regInfo *DOIRegInfo) *DataCite {
+func NewDataCiteFromYAML(info *RepositoryYAML) *DataCite {
 	datacite := NewDataCite()
-	for _, author := range regInfo.Authors {
+	for _, author := range info.Authors {
 		datacite.AddAuthor(&author)
 	}
-	datacite.Titles = []string{regInfo.Title}
-	datacite.AddAbstract(regInfo.Description)
-	datacite.Subjects = regInfo.Keywords
-	datacite.RightsList = []Rights{Rights{Name: regInfo.License.Name, URL: regInfo.License.URL}}
-	for _, funding := range regInfo.Funding {
+	datacite.Titles = []string{info.Title}
+	datacite.AddAbstract(info.Description)
+	datacite.Subjects = info.Keywords
+	datacite.RightsList = []Rights{Rights{Name: info.License.Name, URL: info.License.URL}}
+	for _, funding := range info.Funding {
 		datacite.AddFunding(funding)
 	}
-	for _, ref := range regInfo.References {
+	for _, ref := range info.References {
 		datacite.AddReference(&ref)
 	}
-	datacite.SetResourceType(regInfo.ResourceType)
+	datacite.SetResourceType(info.ResourceType)
 	return &datacite
 }

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -260,3 +260,14 @@ func (dc *DataCite) AddURLs(repo, fork, archive string) {
 		// ignore error and don't add size
 	}
 }
+
+// Marshal returns the marshalled version of the metadata structure, indented
+// with tabs and with the appropriate XML header.
+func (dc *DataCite) Marshal() (string, error) {
+	dataciteXML, err := xml.MarshalIndent(dc, "", "\t")
+	if err != nil {
+		return "", err
+	}
+
+	return xml.Header + string(dataciteXML), nil
+}

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -244,7 +244,7 @@ func NewDataCiteFromYAML(info *RepositoryYAML) *DataCite {
 // as well.
 func (dc *DataCite) AddURLs(repo, fork, archive string) {
 	if repo != "" {
-		relatedIdentifier := RelatedIdentifier{Identifier: repo, Type: "URL", RelationType: "IsSourceOf"}
+		relatedIdentifier := RelatedIdentifier{Identifier: repo, Type: "URL", RelationType: "IsVariantFormOf"}
 		dc.RelatedIdentifiers = append(dc.RelatedIdentifiers, relatedIdentifier)
 	}
 	if fork != "" {
@@ -252,7 +252,7 @@ func (dc *DataCite) AddURLs(repo, fork, archive string) {
 		dc.RelatedIdentifiers = append(dc.RelatedIdentifiers, relatedIdentifier)
 	}
 	if archive != "" {
-		relatedIdentifier := RelatedIdentifier{Identifier: archive, Type: "URL", RelationType: "IsDerivedFrom"}
+		relatedIdentifier := RelatedIdentifier{Identifier: archive, Type: "URL", RelationType: "IsVariantFormOf"}
 		dc.RelatedIdentifiers = append(dc.RelatedIdentifiers, relatedIdentifier)
 		if size, err := getArchiveSize(archive); err == nil {
 			dc.Size = fmt.Sprintf("%d bytes", size) // keep it in bytes so we can humanize it whenever we need to

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -146,7 +146,7 @@ func parseAuthorID(authorID string) *NameIdentifier {
 		var re = regexp.MustCompile(`[[:alpha:]](-[[:digit:]]{4}){2}`)
 		if researcherid := re.Find([]byte(authorID)); researcherid != nil {
 			// TODO: Find the proper values for these (publons.com?)
-			return &NameIdentifier{SchemeURI: "publons.com", Scheme: "ResercherID", ID: string(researcherid)}
+			return &NameIdentifier{SchemeURI: "http://publons.com", Scheme: "ResercherID", ID: string(researcherid)}
 		}
 	}
 	// unknown author ID type, or type identifier and format doesn't match regex: Return full string as ID
@@ -200,7 +200,10 @@ func (dc *DataCite) AddReference(ref *Reference) {
 	refIDParts := strings.SplitN(ref.ID, ":", 2)
 	var relIDType, relID string
 	if len(refIDParts) == 2 {
-		relIDType = relIDTypeMap[strings.ToLower(strings.TrimSpace(refIDParts[0]))]
+		relIDType := strings.TrimSpace(refIDParts[0])
+		if ridt, ok := relIDTypeMap[strings.ToLower(relIDType)]; ok {
+			relIDType = ridt
+		}
 		relID = strings.TrimSpace(refIDParts[1])
 	} else {
 		// No colon, add to ID as is

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -26,6 +26,11 @@ var relIDTypeMap = map[string]string{
 	"pmid":  "PMID",
 }
 
+type Identifier struct {
+	ID   string `xml:",chardata"`
+	Type string `xml:"identifierType,attr"`
+}
+
 type NameIdentifier struct {
 	ID        string `xml:",chardata"`
 	SchemeURI string `xml:"schemeURI,attr"`
@@ -81,6 +86,8 @@ type DataCite struct {
 	Schema         string   `xml:"xmlns:xsi,attr"`
 	Namespace      string   `xml:"xmlns,attr"`
 	SchemaLocation string   `xml:"xsi:schemaLocation,attr"`
+	// Resource identifier (DOI)
+	Identifier Identifier `xml:"identifier"`
 	// Creators: Authors
 	Creators     []Creator     `xml:"creators>creator"`
 	Titles       []string      `xml:"titles>title"`

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -273,7 +273,7 @@ func (dc *DataCite) AddURLs(repo, fork, archive string) {
 	if archive != "" {
 		relatedIdentifier := RelatedIdentifier{Identifier: archive, Type: "URL", RelationType: "IsVariantFormOf"}
 		dc.RelatedIdentifiers = append(dc.RelatedIdentifiers, relatedIdentifier)
-		if size, err := getArchiveSize(archive); err == nil {
+		if size, err := GetArchiveSize(archive); err == nil {
 			dc.Size = fmt.Sprintf("%d bytes", size) // keep it in bytes so we can humanize it whenever we need to
 		}
 		// ignore error and don't add size

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -17,6 +17,15 @@ const (
 	Version        = "1.0"
 )
 
+// relIDTypeMap is used to fix the case of reference types coming from the
+// user's datacite.yml file.
+var relIDTypeMap = map[string]string{
+	"doi":   "DOI",
+	"url":   "URL",
+	"arxiv": "arXiv",
+	"pmid":  "PMID",
+}
+
 type NameIdentifier struct {
 	ID        string `xml:",chardata"`
 	SchemeURI string `xml:"schemeURI,attr"`
@@ -191,7 +200,7 @@ func (dc *DataCite) AddReference(ref *Reference) {
 	refIDParts := strings.SplitN(ref.ID, ":", 2)
 	var relIDType, relID string
 	if len(refIDParts) == 2 {
-		relIDType = strings.TrimSpace(refIDParts[0])
+		relIDType = relIDTypeMap[strings.ToLower(strings.TrimSpace(refIDParts[0]))]
 		relID = strings.TrimSpace(refIDParts[1])
 	} else {
 		// No colon, add to ID as is

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -146,7 +146,7 @@ func parseAuthorID(authorID string) *NameIdentifier {
 		var re = regexp.MustCompile(`[[:alpha:]](-[[:digit:]]{4}){2}`)
 		if researcherid := re.Find([]byte(authorID)); researcherid != nil {
 			// TODO: Find the proper values for these (publons.com?)
-			return &NameIdentifier{SchemeURI: "http://publons.com", Scheme: "ResercherID", ID: string(researcherid)}
+			return &NameIdentifier{SchemeURI: "http://publons.com/researcher/", Scheme: "ResercherID", ID: string(researcherid)}
 		}
 	}
 	// unknown author ID type, or type identifier and format doesn't match regex: Return full string as ID

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -250,12 +250,12 @@ func Test_parseAuthorID(t *testing.T) {
 
 }
 
-func Test_getArchiveSize(t *testing.T) {
+func Test_GetArchiveSize(t *testing.T) {
 	// URL is earliest archive with the new name format, so wont change.
 	// Older archives might be renamed to the new format soon.
 	const archiveURL = "https://doi.gin.g-node.org/10.12751/g-node.4bdb22/10.12751_g-node.4bdb22.zip"
 	const expSize = 1559190240
-	size, err := getArchiveSize(archiveURL)
+	size, err := GetArchiveSize(archiveURL)
 	if err != nil {
 		t.Fatalf("Failed to retrieve archive size for %q: %v", archiveURL, err)
 	}

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -25,9 +25,9 @@ func Test_DataCiteMarshal(t *testing.T) {
 	example.AddFunding("EU, EU.12345")
 	example.SetResourceType("Dataset")
 
-	example.AddReference(&Reference{ID: "doi:10.1111/example.doi", Reftype: "IsDescribedBy", Name: "Manuscript title for reference."})
-	example.AddReference(&Reference{ID: "arxiv:10.2222/example.doi", Reftype: "IsSupplementTo", Name: "Some other work"})
-	example.AddReference(&Reference{ID: "doi:10.3333/example.doi", Reftype: "IsReferencedBy", Name: "A work that references this dataset."})
+	example.AddReference(&Reference{ID: "doi:10.1111/example.doi", RefType: "IsDescribedBy", Name: "Manuscript title for reference."})
+	example.AddReference(&Reference{ID: "arxiv:10.2222/example.doi", RefType: "IsSupplementTo", Name: "Some other work"})
+	example.AddReference(&Reference{ID: "doi:10.3333/example.doi", RefType: "IsReferencedBy", Name: "A work that references this dataset."})
 
 	_, err := xml.MarshalIndent(example, "", "\t")
 	if err != nil {
@@ -59,21 +59,21 @@ func Test_DataCiteFromRegInfo(t *testing.T) {
 	references := []Reference{
 		Reference{
 			ID:      "doi:10.xxx/zzzz",
-			Reftype: "IsSupplementTo",
+			RefType: "IsSupplementTo",
 			Name:    "PublicationName1",
 		},
 		Reference{
 			ID:      "arxiv:mmmm.nnnn",
-			Reftype: "IsDescribedBy",
+			RefType: "IsDescribedBy",
 			Name:    "PublicationName2",
 		},
 		Reference{
 			ID:      "pmid:nnnnnnnn",
-			Reftype: "IsReferencedBy",
+			RefType: "IsReferencedBy",
 			Name:    "PublicationName3",
 		},
 	}
-	regInfo := &DOIRegInfo{
+	regInfo := &RepositoryYAML{
 		Authors:      authors,
 		Title:        "This is a sample",
 		Description:  "This is the abstract",
@@ -83,7 +83,7 @@ func Test_DataCiteFromRegInfo(t *testing.T) {
 		References:   references,
 		ResourceType: "Dataset",
 	}
-	example := NewDataCiteFromRegInfo(regInfo)
+	example := NewDataCiteFromYAML(regInfo)
 	dataciteXML, err := xml.MarshalIndent(example, "", "\t")
 	if err != nil {
 		t.Fatalf("Failed to marshal: %v\n", err)

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -249,3 +249,18 @@ func Test_parseAuthorID(t *testing.T) {
 	}
 
 }
+
+func Test_getArchiveSize(t *testing.T) {
+	// URL is earliest archive with the new name format, so wont change.
+	// Older archives might be renamed to the new format soon.
+	const archiveURL = "https://doi.gin.g-node.org/10.12751/g-node.4bdb22/10.12751_g-node.4bdb22.zip"
+	const expSize = 1559190240
+	size, err := getArchiveSize(archiveURL)
+	if err != nil {
+		t.Fatalf("Failed to retrieve archive size for %q: %v", archiveURL, err)
+	}
+
+	if size != expSize {
+		t.Fatalf("Incorrect archive size: %d (expected) != %d", expSize, size)
+	}
+}

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -39,6 +39,12 @@ type RepositoryYAML struct {
 	ResourceType    string `yaml:"resourcetype"`
 }
 
+type GINUser struct {
+	Username string
+	Email    string
+	RealName string
+}
+
 // RepositoryMetadata can contain all known metadata for a registered (or
 // to-be-registered) repository. To do this, it embeds the
 type RepositoryMetadata struct {
@@ -49,6 +55,8 @@ type RepositoryMetadata struct {
 	// The following are computed or generated from external info and don't
 	// show up in the YAML or XML files
 
+	// The user that sent the request
+	RequestingUser *GINUser
 	// Should be full repository path (<user>/<reponame>)
 	SourceRepository string
 	// Should be full repository path of the snapshot fork (doi/<rpeoname>)

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -71,12 +71,6 @@ type RepositoryMetadata struct {
 	DOI string
 	// UUID calculated from unique repository path or randomly assigned
 	UUID string
-	// URL to the registered dataset archive
-	ArchiveURL string
-	// URL to the landing page of the published dataset
-	PageURL string
-	// File size for the archive (in bytes)
-	ArchiveSize int
 	// Registration date (time can also be stored, but is not necessary)
 	DateTime time.Time
 }

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -15,28 +15,34 @@ import (
 // through the datacite.yml file. This data is usually used to populate the
 // DataCite and RepositoryMetadata types.
 type RepositoryYAML struct {
-	Authors []struct {
-		FirstName   string `yaml:"firstname"`
-		LastName    string `yaml:"lastname"`
-		Affiliation string `yaml:"affiliation,omitempty"`
-		ID          string `yaml:"id,omitempty"`
-	}
-	Title       string `yaml:"title"`
-	Description string
-	Keywords    []string `yaml:"keywords"`
-	License     struct {
-		Name string `yaml:"name"`
-		URL  string `yaml:"url"`
-	}
-	Funding    []string `yaml:"funding,omitempty"`
-	References struct {
-		ID       string `yaml:"string"`
-		RefType  string `yaml:"reftype"`
-		Name     string `yaml:"name"`     // deprecated, but still read for older versions
-		Citation string `yaml:"citation"` // meant to replace Name
-	}
+	Authors         []Author
+	Title           string `yaml:"title"`
+	Description     string
+	Keywords        []string `yaml:"keywords"`
+	License         *License
+	Funding         []string `yaml:"funding,omitempty"`
+	References      []Reference
 	TemplateVersion string `yaml:"templateversion,omitempty"`
 	ResourceType    string `yaml:"resourcetype"`
+}
+
+type Author struct {
+	FirstName   string `yaml:"firstname"`
+	LastName    string `yaml:"lastname"`
+	Affiliation string `yaml:"affiliation,omitempty"`
+	ID          string `yaml:"id,omitempty"`
+}
+
+type License struct {
+	Name string `yaml:"name"`
+	URL  string `yaml:"url"`
+}
+
+type Reference struct {
+	ID       string `yaml:"string"`
+	RefType  string `yaml:"reftype"`
+	Name     string `yaml:"name"`     // deprecated, but still read for older versions
+	Citation string `yaml:"citation"` // meant to replace Name
 }
 
 type GINUser struct {
@@ -158,13 +164,6 @@ func (c *DOIRegInfo) PrettyDate() string {
 	return c.DateTime.Format("02 Jan. 2006")
 }
 
-type Author struct {
-	FirstName   string
-	LastName    string
-	Affiliation string
-	ID          string
-}
-
 func (c *Author) GetValidID() *NamedIdentifier {
 	if c.ID == "" {
 		return nil
@@ -188,13 +187,6 @@ type NamedIdentifier struct {
 	SchemeURI string
 	Scheme    string
 	ID        string
-}
-
-type Reference struct {
-	Reftype  string
-	Name     string
-	Citation string
-	ID       string
 }
 
 func (ref Reference) GetURL() string {
@@ -222,11 +214,6 @@ func (ref Reference) GetURL() string {
 	}
 
 	return fmt.Sprintf("%s%s", prefix, idnum)
-}
-
-type License struct {
-	Name string
-	URL  string
 }
 
 func IsRegisteredDOI(doi string) bool {

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -15,15 +15,15 @@ import (
 // through the datacite.yml file. This data is usually used to populate the
 // DataCite and RepositoryMetadata types.
 type RepositoryYAML struct {
-	Authors         []Author
-	Title           string `yaml:"title"`
-	Description     string
-	Keywords        []string `yaml:"keywords"`
-	License         *License
-	Funding         []string `yaml:"funding,omitempty"`
-	References      []Reference
-	TemplateVersion string `yaml:"templateversion,omitempty"`
-	ResourceType    string `yaml:"resourcetype"`
+	Authors         []Author    `yaml:"authors"`
+	Title           string      `yaml:"title"`
+	Description     string      `yaml:"description"`
+	Keywords        []string    `yaml:"keywords"`
+	License         *License    `yaml:"license,omitempty"`
+	Funding         []string    `yaml:"funding,omitempty"`
+	References      []Reference `yaml:"references,omitempty"`
+	TemplateVersion string      `yaml:"templateversion,omitempty"`
+	ResourceType    string      `yaml:"resourcetype"`
 }
 
 type Author struct {
@@ -39,10 +39,10 @@ type License struct {
 }
 
 type Reference struct {
-	ID       string `yaml:"string"`
-	RefType  string `yaml:"reftype"`
-	Name     string `yaml:"name"`     // deprecated, but still read for older versions
-	Citation string `yaml:"citation"` // meant to replace Name
+	ID       string `yaml:"string,omitempty"`
+	RefType  string `yaml:"reftype,omitempty"`
+	Name     string `yaml:"name,omitempty"`     // deprecated, but still read for older versions
+	Citation string `yaml:"citation,omitempty"` // meant to replace Name
 }
 
 type GINUser struct {

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -69,8 +69,6 @@ type RepositoryMetadata struct {
 	ForkRepository string
 	// UUID calculated from unique repository path or randomly assigned
 	UUID string
-	// Registration date (time can also be stored, but is not necessary)
-	DateTime time.Time
 }
 
 // NOTE: TEMPORARY COPIES FROM gin-doi

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -67,8 +67,6 @@ type RepositoryMetadata struct {
 	SourceRepository string
 	// Should be full repository path of the snapshot fork (doi/<rpeoname>)
 	ForkRepository string
-	// The calculated or assigned DOI
-	DOI string
 	// UUID calculated from unique repository path or randomly assigned
 	UUID string
 	// Registration date (time can also be stored, but is not necessary)

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -39,7 +39,7 @@ type License struct {
 }
 
 type Reference struct {
-	ID       string `yaml:"string,omitempty"`
+	ID       string `yaml:"id,omitempty"`
 	RefType  string `yaml:"reftype,omitempty"`
 	Name     string `yaml:"name,omitempty"`     // deprecated, but still read for older versions
 	Citation string `yaml:"citation,omitempty"` // meant to replace Name

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -11,6 +11,62 @@ import (
 	"time"
 )
 
+// RepositoryYAML is used to read the information provided by a GIN user
+// through the datacite.yml file. This data is usually used to populate the
+// DataCite and RepositoryMetadata types.
+type RepositoryYAML struct {
+	Authors []struct {
+		FirstName   string `yaml:"firstname"`
+		LastName    string `yaml:"lastname"`
+		Affiliation string `yaml:"affiliation,omitempty"`
+		ID          string `yaml:"id,omitempty"`
+	}
+	Title       string `yaml:"title"`
+	Description string
+	Keywords    []string `yaml:"keywords"`
+	License     struct {
+		Name string `yaml:"name"`
+		URL  string `yaml:"url"`
+	}
+	Funding    []string `yaml:"funding,omitempty"`
+	References struct {
+		ID       string `yaml:"string"`
+		RefType  string `yaml:"reftype"`
+		Name     string `yaml:"name"`     // deprecated, but still read for older versions
+		Citation string `yaml:"citation"` // meant to replace Name
+	}
+	TemplateVersion string `yaml:"templateversion,omitempty"`
+	ResourceType    string `yaml:"resourcetype"`
+}
+
+// RepositoryMetadata can contain all known metadata for a registered (or
+// to-be-registered) repository. To do this, it embeds the
+type RepositoryMetadata struct {
+	// YAMLData is the original data coming from the repository
+	YAMLData *RepositoryYAML
+	// DataCite is the struct that produces the XML file
+	*DataCite
+	// The following are computed or generated from external info and don't
+	// show up in the YAML or XML files
+
+	// Should be full repository path (<user>/<reponame>)
+	SourceRepository string
+	// Should be full repository path of the snapshot fork (doi/<rpeoname>)
+	ForkRepository string
+	// The calculated or assigned DOI
+	DOI string
+	// UUID calculated from unique repository path or randomly assigned
+	UUID string
+	// URL to the registered dataset archive
+	ArchiveURL string
+	// URL to the landing page of the published dataset
+	PageURL string
+	// File size for the archive (in bytes)
+	ArchiveSize int
+	// Registration date (time can also be stored, but is not necessary)
+	DateTime time.Time
+}
+
 // NOTE: TEMPORARY COPIES FROM gin-doi
 
 // UUIDMap is a map between registered repositories and their UUIDs for

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -59,7 +59,7 @@ type RepositoryMetadata struct {
 	// DataCite is the struct that produces the XML file
 	*DataCite
 	// The following are computed or generated from external info and don't
-	// show up in the YAML or XML files
+	// all show up in the YAML or XML files
 
 	// The user that sent the request
 	RequestingUser *GINUser
@@ -109,6 +109,7 @@ type DOIRequestData struct {
 }
 
 // DOIRegInfo holds all the metadata and information necessary for a DOI registration request.
+// Deprecated and obsolete: Marked for removal
 type DOIRegInfo struct {
 	Missing         []string
 	DOI             string
@@ -154,8 +155,8 @@ func (c *DOIRegInfo) ISODate() string {
 	return c.DateTime.Format("2006-01-02")
 }
 
-func (c *DOIRegInfo) PrettyDate() string {
-	return c.DateTime.Format("02 Jan. 2006")
+func PrettyDate(dt *time.Time) string {
+	return dt.Format("02 Jan. 2006")
 }
 
 func (c *Author) GetValidID() *NamedIdentifier {

--- a/libgin/util.go
+++ b/libgin/util.go
@@ -3,6 +3,8 @@ package libgin
 // Common utilities for the GIN services
 
 import (
+	"fmt"
+	"net/http"
 	"os"
 )
 
@@ -21,4 +23,21 @@ func ReadConfDefault(key, defval string) string {
 func ReadConf(key string) string {
 	value, _ := os.LookupEnv(key)
 	return value
+}
+
+// getArchiveSize returns the size of the archive at the given URL.
+// If the URL is invalid or unreachable, an error is returned.
+func getArchiveSize(archiveURL string) (uint64, error) {
+	resp, err := http.Get(archiveURL)
+	if err != nil {
+		return 0, fmt.Errorf("Request for archive %q failed: %s\n", archiveURL, err.Error())
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("Request for archive %q failed: %s\n", archiveURL, resp.Status)
+	}
+	if resp.ContentLength < 0 {
+		// returns -1 when size is unknown; let's turn it into an error
+		return 0, fmt.Errorf("Unable to determine size of %q", archiveURL)
+	}
+	return uint64(resp.ContentLength), nil
 }

--- a/libgin/util.go
+++ b/libgin/util.go
@@ -25,9 +25,9 @@ func ReadConf(key string) string {
 	return value
 }
 
-// getArchiveSize returns the size of the archive at the given URL.
+// GetArchiveSize returns the size of the archive at the given URL.
 // If the URL is invalid or unreachable, an error is returned.
-func getArchiveSize(archiveURL string) (uint64, error) {
+func GetArchiveSize(archiveURL string) (uint64, error) {
 	resp, err := http.Get(archiveURL)
 	if err != nil {
 		return 0, fmt.Errorf("Request for archive %q failed: %s\n", archiveURL, err.Error())


### PR DESCRIPTION
Following up from #14 we now have a new struct called `RepositoryMetadata` that embeds the new `DataCite` struct as well as another new struct called `RepositoryYAML`.  The latter replaces the old `DOIRegInfo` and other sub-structs into one that contains YAML tags for all the data we can read from the `datacite.yml` of a GIN repository.

Some of the older structs are now obsolete, but this will be done at a later date when we have finalised the usage of these changes in gin-doi.

The PR also contains fixes for some of the convenience functions and methods for the DataCite struct, as well as some new ones.

