### PR TITLE
XML namespace attribute fixes

### DIFF
--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -3,6 +3,8 @@ package libgin
 import (
 	"encoding/xml"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -10,7 +12,6 @@ import (
 
 const (
 	Schema         = "http://www.w3.org/2001/XMLSchema-instance"
-	Namespace      = "http://datacite.org/schema/kernel-4"
 	SchemaLocation = "http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd"
 	Publisher      = "G-Node"
 	Language       = "eng"
@@ -82,9 +83,8 @@ type ResourceType struct {
 }
 
 type DataCite struct {
-	XMLName        xml.Name `xml:"resource"`
+	XMLName        xml.Name `xml:"http://datacite.org/schema/kernel-4 resource"`
 	Schema         string   `xml:"xmlns:xsi,attr"`
-	Namespace      string   `xml:"xmlns,attr"`
 	SchemaLocation string   `xml:"xsi:schemaLocation,attr"`
 	// Resource identifier (DOI)
 	Identifier Identifier `xml:"identifier"`
@@ -123,8 +123,8 @@ type DataCite struct {
 // changed when working with an existing publication.
 func NewDataCite() DataCite {
 	return DataCite{
+		XMLName:        xml.Name{Space: "http://datacite.org/schema/kernel-4", Local: "resource"},
 		Schema:         Schema,
-		Namespace:      Namespace,
 		SchemaLocation: SchemaLocation,
 		Contributors:   []Contributor{Contributor{"German Neuroinformatics Node", "HostingInstitution"}},
 		Publisher:      Publisher,
@@ -158,6 +158,15 @@ func parseAuthorID(authorID string) *NameIdentifier {
 	}
 	// unknown author ID type, or type identifier and format doesn't match regex: Return full string as ID
 	return &NameIdentifier{SchemeURI: "", Scheme: "", ID: string(authorID)}
+}
+
+// FixSchemaAttrs adds the Schema and SchemaLocation attributes that can't be
+// read from existing files when Unmarshaling.  See
+// https://github.com/golang/go/issues/9519 for the issue with attributes that
+// have a namespace prefix.
+func (dc *DataCite) FixSchemaAttrs() {
+	dc.Schema = Schema
+	dc.SchemaLocation = SchemaLocation
 }
 
 func (dc *DataCite) AddAuthor(author *Author) {
@@ -253,6 +262,29 @@ func NewDataCiteFromYAML(info *RepositoryYAML) *DataCite {
 	}
 	datacite.SetResourceType(info.ResourceType)
 	return &datacite
+}
+
+// UnmarshalFile reads an XML file specified by the given path and returns a
+// populated DataCite struct.  Before returning, it adds the schema attributes
+// for the top-level tag.  See also FixSchemaAttrs.
+func UnmarshalFile(path string) (*DataCite, error) {
+	fp, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	xmldata, err := ioutil.ReadAll(fp)
+	if err != nil {
+		return nil, err
+	}
+	dc := new(DataCite)
+	err = xml.Unmarshal(xmldata, dc)
+
+	if err != nil {
+		return nil, err
+	}
+	dc.FixSchemaAttrs()
+	return dc, nil
 }
 
 // AddURLs is a convenience function for appending three reference URLs:

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -272,6 +272,7 @@ func UnmarshalFile(path string) (*DataCite, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer fp.Close()
 
 	xmldata, err := ioutil.ReadAll(fp)
 	if err != nil {

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -3,8 +3,12 @@ package libgin
 import (
 	"encoding/xml"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -257,10 +261,77 @@ func Test_GetArchiveSize(t *testing.T) {
 	const expSize = 1559190240
 	size, err := GetArchiveSize(archiveURL)
 	if err != nil {
-		t.Fatalf("Failed to retrieve archive size for %q: %v", archiveURL, err)
+		t.Fatalf("Failed to retrieve archive size for %q: %v", archiveURL, err.Error())
 	}
 
 	if size != expSize {
 		t.Fatalf("Incorrect archive size: %d (expected) != %d", expSize, size)
+	}
+}
+
+func Test_MarshalUnmarshal(t *testing.T) {
+	example := NewDataCite()
+	example.Creators = []Creator{
+		Creator{"Achilleas", &NameIdentifier{"0010", "http://orcid.org", "ORCID"}, "University of Bob"},
+		Creator{"Bob", &NameIdentifier{"1111", "http://orcid.org", "ORCID"}, "University of University"},
+		Creator{"Orphan", nil, ""},
+	}
+
+	example.Titles = []string{"This is a sample"}
+	example.AddAbstract("This is the abstract")
+	example.RightsList = []Rights{Rights{"CC-BY", "http://creativecommons.org/licenses/by/4.0/"}}
+	example.Subjects = []string{"One", "Two", "Three"}
+	example.AddFunding("DFG, DFG.12345")
+	example.AddFunding("EU, EU.12345")
+	example.SetResourceType("Dataset")
+
+	example.AddReference(&Reference{ID: "doi:10.1111/example.doi", RefType: "IsDescribedBy", Name: "Manuscript title for reference."})
+	example.AddReference(&Reference{ID: "arxiv:10.2222/example.doi", RefType: "IsSupplementTo", Name: "Some other work"})
+	example.AddReference(&Reference{ID: "doi:10.3333/example.doi", RefType: "IsReferencedBy", Name: "A work that references this dataset."})
+
+	wdata, err := example.Marshal()
+	if err != nil {
+		t.Fatalf("Failed to marshal example data: %v", err.Error())
+	}
+
+	// Write data to temporary file and use UnmarshalFile() convenience function
+	tmpdir, err := ioutil.TempDir("", "datacite-test")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+	fname := filepath.Join(tmpdir, "datacite.xml")
+	err = ioutil.WriteFile(fname, []byte(wdata), os.ModePerm)
+	if err != nil {
+		t.Fatalf("Failed to write marshalled data: %v", err.Error())
+	}
+
+	exampleRead, err := UnmarshalFile(fname)
+	if err != nil {
+		t.Fatalf("Failed to read XML file: %v", err.Error())
+	}
+
+	// marshal again and compare line by line
+	rdata, err := exampleRead.Marshal()
+	if err != nil {
+		t.Fatalf("Failed to marshal read data: %v", err.Error())
+	}
+
+	if len(wdata) != len(rdata) {
+		t.Fatalf("Written and read data have different length: %d != %d", len(wdata), len(rdata))
+	}
+
+	wdataLines := strings.Split(wdata, "\n")
+	rdataLines := strings.Split(rdata, "\n")
+
+	if len(wdataLines) != len(rdataLines) {
+		t.Fatalf("Written and read data have different number of lines: %d != %d", len(wdataLines), len(rdataLines))
+	}
+
+	for idx, rline := range rdataLines {
+		wline := wdataLines[idx]
+		if wline != rline {
+			t.Fatalf("Mismatched line at %d: %s != %s", idx, wline, rline)
+		}
 	}
 }

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -8,7 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"strings"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -311,27 +311,7 @@ func Test_MarshalUnmarshal(t *testing.T) {
 		t.Fatalf("Failed to read XML file: %v", err.Error())
 	}
 
-	// marshal again and compare line by line
-	rdata, err := exampleRead.Marshal()
-	if err != nil {
-		t.Fatalf("Failed to marshal read data: %v", err.Error())
-	}
-
-	if len(wdata) != len(rdata) {
-		t.Fatalf("Written and read data have different length: %d != %d", len(wdata), len(rdata))
-	}
-
-	wdataLines := strings.Split(wdata, "\n")
-	rdataLines := strings.Split(rdata, "\n")
-
-	if len(wdataLines) != len(rdataLines) {
-		t.Fatalf("Written and read data have different number of lines: %d != %d", len(wdataLines), len(rdataLines))
-	}
-
-	for idx, rline := range rdataLines {
-		wline := wdataLines[idx]
-		if wline != rline {
-			t.Fatalf("Mismatched line at %d: %s != %s", idx, wline, rline)
-		}
+	if !reflect.DeepEqual(example, *exampleRead) {
+		t.Fatalf("Original data does not match reread data")
 	}
 }


### PR DESCRIPTION
It seems that unmarshaling XML data with attributes that have custom
namespace prefixes isn't fully supported:
https://github.com/golang/go/issues/9519

Adjusted the top-level tag's (resource) namespace attribute to be
included in the XMLName field's tags.  More importantly, there's a new
DataCite method for fixing the schema attributes, since they're not
properly loaded when reading existing XML files.

Also, a new loader function takes a filename and loads the data into a
new DataCite struct, then runs the FixSchemaAttrs() method before
returning the loaded structure.

~~Test included that writes a file, reads it back, then re-marshals the read data and compares with the original.~~
Test included that writes a file, loads it back, and compares with the original using `reflect.DeepEqual()`.