### PR TITLE
Indent with 2 spaces instead of tabs

### DIFF
--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -316,7 +316,7 @@ func (dc *DataCite) AddURLs(repo, fork, archive string) {
 // Marshal returns the marshalled version of the metadata structure, indented
 // with tabs and with the appropriate XML header.
 func (dc *DataCite) Marshal() (string, error) {
-	dataciteXML, err := xml.MarshalIndent(dc, "", "\t")
+	dataciteXML, err := xml.MarshalIndent(dc, "", "  ")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Our old XML files were 2-space indented and this seems to be common, so
might as well stick to it.