### PR TITLE
Minor change to reference description

### DIFF
--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -274,7 +274,7 @@ func (dc *DataCite) AddReference(ref *Reference) {
 	if !strings.HasSuffix(namecitation, ".") {
 		namecitation += "."
 	}
-	refDesc := Description{Content: fmt.Sprintf("%s: %s (%s)", ref.RefType, namecitation, ref.ID), Type: "Other"}
+	refDesc := Description{Content: fmt.Sprintf("%s: %s (%s:%s)", ref.RefType, namecitation, relIDType, relID), Type: "Other"}
 
 	dc.Descriptions = append(dc.Descriptions, refDesc)
 }


### PR DESCRIPTION
This way we get the correct capitalisation of the reference ID type in the human-readable reference string (description).
This means: DOI, arXiv, PMID, URL are capitalised regardless of the user's input.