### PR TITLE
Correctly return URL for URL-type references

### DIFF
--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -199,6 +199,9 @@ func (ref Reference) GetURL() string {
 	case "pmid":
 		// https://www.ncbi.nlm.nih.gov/books/NBK3862/#linkshelp.Retrieve_PubMed_Citations
 		prefix = "https://www.ncbi.nlm.nih.gov/pubmed/"
+	case "url":
+		// simple URL: no prefix
+		prefix = ""
 	default:
 		// Return an empty string to make the reflink inactive
 		return ""


### PR DESCRIPTION
When a dataset's metadata includes a reference as a URL in the form `URL:https://...`, link to the URL directly without a prefix so that it works correctly in the landing page.