### PR TITLE
Add full DOI URL in references

### DIFF
--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -274,7 +274,7 @@ func (dc *DataCite) AddReference(ref *Reference) {
 	if !strings.HasSuffix(namecitation, ".") {
 		namecitation += "."
 	}
-	refDesc := Description{Content: fmt.Sprintf("%s: %s (%s:%s)", ref.RefType, namecitation, relIDType, relID), Type: "Other"}
+	refDesc := Description{Content: fmt.Sprintf("%s: %s (%s)", ref.RefType, namecitation, ref.GetURL()), Type: "Other"}
 
 	dc.Descriptions = append(dc.Descriptions, refDesc)
 }

--- a/libgin/doi.go
+++ b/libgin/doi.go
@@ -140,7 +140,7 @@ func (c *DOIRegInfo) GetCitation() string {
 			authors += fmt.Sprintf("%s, ", auth.LastName)
 		}
 	}
-	return fmt.Sprintf("%s (%s) %s. G-Node. doi:%s", authors, c.Year(), c.Title, c.DOI)
+	return fmt.Sprintf("%s (%s) %s. G-Node. https://doi.org/%s", authors, c.Year(), c.Title, c.DOI)
 }
 
 func (c *DOIRegInfo) Year() string {


### PR DESCRIPTION
Reference descriptions (citations) are added with full "https://doi.org/<DOI>" URL (or equivalent for other sources) at the end.
The landing page citation is also changed to match.

Counterpart to g-node/gin-doi#46.