### PR TITLE
Fixes in XML creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+cwd = $(shell pwd)
+SOURCES = $(shell find . -type f -iname "*.go") go.mod go.sum
+
+.PHONY: test coverage showcoverage
+
+test: coverage
+
+coverage: $(SOURCES)
+	go test -coverpkg=./... -coverprofile=coverage ./...
+
+showcoverage: coverage
+	go tool cover -html=coverage

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -31,26 +31,26 @@ var relIDTypeMap = map[string]string{
 // This is currently populated from the existing registered datasets.
 // A more comprehensive list may be added later.
 var funderIDMap = map[string]string{
-	"BMBF":                       "https://doi.org/10.13039/501100002347",
-	"Boehringer Ingelheim Fonds": "https://doi.org/10.13039/501100001645",
-	"CNRS":                       "https://doi.org/10.13039/501100004794",
-	"DAAD":                       "https://doi.org/10.13039/501100001655",
-	"DFG":                        "https://doi.org/10.13039/501100001659",
-	"Einstein Foundation Berlin": "https://doi.org/10.13039/501100006188",
-	"Einstein Stiftung":          "https://doi.org/10.13039/501100006188",
-	"EU":                         "https://doi.org/10.13039/100010664",
-	"European Union’s Horizon 2020 Framework Programme for Research and Innovation under the Specific Grant Agreements No. 720270 and No. 785907 (Human Brain Project SGA1 and SGA2; to M.M. and P.A.)": "https://doi.org/10.13039/100010661",
-	"European Union's Seventh Framework Programme (FP/2007-2013)": "https://doi.org/10.13039/100011102",
-	"Helmholtz Association":           "https://doi.org/10.13039/501100001656",
-	"Human Frontiers Science Program": "https://doi.org/10.13039/501100000854",
-	"Innovate UK":                     "https://dx.doi.org/10.13039/501100006041",
-	"Max Planck Society":              "https://doi.org/10.13039/501100004189",
+	"EU":                              "https://doi.org/10.13039/100010664",
+	"BMBF":                            "https://ror.org/04pz7b180",
+	"CNRS":                            "https://ror.org/02feahw73",
+	"DAAD":                            "https://ror.org/039djdh30",
+	"DFG":                             "https://ror.org/018mejw64",
+	"NIH":                             "https://ror.org/01cwqze88",
+	"NSF":                             "https://ror.org/00yjd3n13",
+	"Boehringer Ingelheim Fonds":      "https://ror.org/00dkye506",
+	"Einstein Foundation Berlin":      "https://ror.org/03s0fv852",
+	"Einstein Stiftung":               "https://ror.org/03s0fv852",
+	"Helmholtz Association":           "https://ror.org/0281dp749",
+	"Human Frontiers Science Program": "https://ror.org/02ebx7v45",
+	"Innovate UK":                     "https://ror.org/019wvm592",
+	"Max Planck Society":              "https://ror.org/01hhn8329",
+	"The JPB Foundation":              "https://ror.org/05nzwyq50",
+	"National Institute on Deafness and Other Communication Disorders":                                               "https://ror.org/04mhx6838",
+	"Seventh Framework Programme (European Union Seventh Framework Programme)":                                       "https://doi.org/10.13039/100011102",
+	"European Union's Seventh Framework Programme (FP/2007-2013)":                                                    "https://doi.org/10.13039/100011102",
 	"Ministry of Science, Research, and the Arts of the State of Baden-Württemberg (MWK), Juniorprofessor programme": "https://doi.org/10.13039/501100003542",
-	"National Institute on Deafness and Other Communication Disorders":                                               "https://doi.org/10.13039/100000055",
-	"NIH": "https://doi.org/10.13039/100000002",
-	"NSF": "https://doi.org/10.13039/100000001",
-	"Seventh Framework Programme (European Union Seventh Framework Programme)": "https://doi.org/10.13039/100011102",
-	"The JPB Foundation": "https://doi.org/10.13039/100007457",
+	"European Union’s Horizon 2020 Framework Programme for Research and Innovation under the Specific Grant Agreements No. 720270 and No. 785907 (Human Brain Project SGA1 and SGA2; to M.M. and P.A.)": "https://ror.org/00k4n6c32",
 }
 
 type Identifier struct {
@@ -236,7 +236,13 @@ func (dc *DataCite) AddFunding(fundstr string) {
 	}
 	fundref := FundingReference{Funder: funder, AwardNumber: awardNumber}
 	if id, known := funderIDMap[funder]; known {
-		fundref.Identifier = &FunderIdentifier{ID: id, Type: "Crossref Funder ID"}
+		idtype := ""
+		if strings.Contains(id, "ror.org") {
+			idtype = "ROR"
+		} else if strings.Contains(id, "doi.org") {
+			idtype = "Crossref Funder ID"
+		}
+		fundref.Identifier = &FunderIdentifier{ID: id, Type: idtype}
 	}
 	if dc.FundingReferences == nil {
 		dc.FundingReferences = &[]FundingReference{}

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	Schema         = "http://www.w3.org/2001/XMLSchema-instance"
-	SchemaLocation = "http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd"
+	SchemaLocation = "http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.3/metadata.xsd"
 	Publisher      = "G-Node"
 	Language       = "eng"
 	Version        = "1.0"

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -142,7 +142,7 @@ type DataCite struct {
 	Language     string       `xml:"language"`
 	ResourceType ResourceType `xml:"resourceType"`
 	// Size of the archive
-	Size string `xml:"size,omitempty"`
+	Sizes []string `xml:"sizes>size,omitempty"`
 	// Version: 1.0
 	Version string `xml:"version"`
 }
@@ -341,7 +341,7 @@ func (dc *DataCite) AddURLs(repo, fork, archive string) {
 		relatedIdentifier := RelatedIdentifier{Identifier: archive, Type: "URL", RelationType: "IsVariantFormOf"}
 		dc.RelatedIdentifiers = append(dc.RelatedIdentifiers, relatedIdentifier)
 		if size, err := GetArchiveSize(archive); err == nil {
-			dc.Size = fmt.Sprintf("%d bytes", size) // keep it in bytes so we can humanize it whenever we need to
+			dc.Sizes = []string{fmt.Sprintf("%d bytes", size)} // keep it in bytes so we can humanize it whenever we need to
 		}
 		// ignore error and don't add size
 	}

--- a/libgin/datacite.go
+++ b/libgin/datacite.go
@@ -126,10 +126,10 @@ type DataCite struct {
 	// RightsList: Licenses
 	RightsList []Rights `xml:"rightsList>rights"`
 	// Subjects: Keywords
-	Subjects []string `xml:"subjects>subject,omitempty"`
+	Subjects *[]string `xml:"subjects>subject,omitempty"`
 	// RelatedIdentifiers: References
-	RelatedIdentifiers []RelatedIdentifier `xml:"relatedIdentifiers>relatedIdentifier,omitempty"`
-	FundingReferences  []FundingReference  `xml:"fundingReferences>fundingReference,omitempty"`
+	RelatedIdentifiers []RelatedIdentifier `xml:"relatedIdentifiers>relatedIdentifier"`
+	FundingReferences  *[]FundingReference `xml:"fundingReferences>fundingReference,omitempty"`
 	// Contributors: Always German Neuroinformatics Node with type "HostingInstitution"
 	Contributors []Contributor `xml:"contributors>contributor"`
 	// Publisher: Always G-Node
@@ -142,7 +142,7 @@ type DataCite struct {
 	Language     string       `xml:"language"`
 	ResourceType ResourceType `xml:"resourceType"`
 	// Size of the archive
-	Sizes []string `xml:"sizes>size,omitempty"`
+	Sizes *[]string `xml:"sizes>size,omitempty"`
 	// Version: 1.0
 	Version string `xml:"version"`
 }
@@ -238,7 +238,10 @@ func (dc *DataCite) AddFunding(fundstr string) {
 	if id, known := funderIDMap[funder]; known {
 		fundref.Identifier = &FunderIdentifier{ID: id, Type: "Crossref Funder ID"}
 	}
-	dc.FundingReferences = append(dc.FundingReferences, fundref)
+	if dc.FundingReferences == nil {
+		dc.FundingReferences = &[]FundingReference{}
+	}
+	*dc.FundingReferences = append(*dc.FundingReferences, fundref)
 }
 
 // AddReference is a convenience function for appending a RelatedIdentifier
@@ -286,7 +289,7 @@ func NewDataCiteFromYAML(info *RepositoryYAML) *DataCite {
 	}
 	datacite.Titles = []string{info.Title}
 	datacite.AddAbstract(info.Description)
-	datacite.Subjects = info.Keywords
+	datacite.Subjects = &info.Keywords
 	datacite.RightsList = []Rights{Rights{Name: info.License.Name, URL: info.License.URL}}
 	for _, funding := range info.Funding {
 		datacite.AddFunding(funding)
@@ -341,7 +344,7 @@ func (dc *DataCite) AddURLs(repo, fork, archive string) {
 		relatedIdentifier := RelatedIdentifier{Identifier: archive, Type: "URL", RelationType: "IsVariantFormOf"}
 		dc.RelatedIdentifiers = append(dc.RelatedIdentifiers, relatedIdentifier)
 		if size, err := GetArchiveSize(archive); err == nil {
-			dc.Sizes = []string{fmt.Sprintf("%d bytes", size)} // keep it in bytes so we can humanize it whenever we need to
+			dc.Sizes = &[]string{fmt.Sprintf("%d bytes", size)} // keep it in bytes so we can humanize it whenever we need to
 		}
 		// ignore error and don't add size
 	}

--- a/libgin/datacite_test.go
+++ b/libgin/datacite_test.go
@@ -24,7 +24,7 @@ func Test_DataCiteMarshal(t *testing.T) {
 	example.Titles = []string{"This is a sample"}
 	example.AddAbstract("This is the abstract")
 	example.RightsList = []Rights{Rights{"CC-BY", "http://creativecommons.org/licenses/by/4.0/"}}
-	example.Subjects = []string{"One", "Two", "Three"}
+	example.Subjects = &[]string{"One", "Two", "Three"}
 	example.AddFunding("DFG, DFG.12345")
 	example.AddFunding("EU, EU.12345")
 	example.SetResourceType("Dataset")
@@ -280,7 +280,7 @@ func Test_MarshalUnmarshal(t *testing.T) {
 	example.Titles = []string{"This is a sample"}
 	example.AddAbstract("This is the abstract")
 	example.RightsList = []Rights{Rights{"CC-BY", "http://creativecommons.org/licenses/by/4.0/"}}
-	example.Subjects = []string{"One", "Two", "Three"}
+	example.Subjects = &[]string{"One", "Two", "Three"}
 	example.AddFunding("DFG, DFG.12345")
 	example.AddFunding("EU, EU.12345")
 	example.SetResourceType("Dataset")


### PR DESCRIPTION
- Dataset size should be a list of sizes with one element (per DataCite spec).
- Optional DataCite tags (like FundingReferences) are pointers so that they wont appear in the XML when they're empty.
- Using v4.3 of the DataCite schema.
- Changed FunderIDs to ROR IDs (where available).